### PR TITLE
RNUserdefaults.get/getFromSuite to return object

### DIFF
--- a/ios/RNUserdefaults.swift
+++ b/ios/RNUserdefaults.swift
@@ -26,7 +26,7 @@ public class RNUserdefaults: NSObject {
     @objc
     public func getFromSuite(_ key: String, inSuite suite: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         let defaults = determineUserDefaults(inSuite: suite)
-        let value = defaults.object(forKey: key) as? String
+        let value = defaults.object(forKey: key)
         resolve(value)
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,8 @@
 export type RNUserdefaultsType = {
   set: (value: string, key: string) => void;
   setFromSuite: (value: string, key: string, suite: string) => void;
-  get: (key: string) => Promise<string | undefined>;
-  getFromSuite: (key: string, suite: string) => Promise<string | undefined>;
+  get: (key: string) => Promise<any | undefined>;
+  getFromSuite: (key: string, suite: string) => Promise<any | undefined>;
   remove: (key: string) => void;
   removeFromSuite: (key: string, suite: string) => void;
 };


### PR DESCRIPTION
The reason of this change is that sometimes it requires to store some data(object) via native ObjC/Swift part and later access it via ReactNative.

I found this lib can only access strings which is an issue.

With this change we allow to access objects as well 